### PR TITLE
Better handling of parents / clones and of the scraped list

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -98,7 +98,7 @@ def dat_clean(roms_to_keep, dat_file, dat_out=None, accuracy=90):
             if parent_name:
                 cloneof_to_keep.append(parent_name)
     
-    to_delete = [i for i in to_delete if i.get('name') not in cloneof_to_keep or i.get('cloneof') not in cloneof_to_keep]
+    to_delete = [i for i in to_delete if i.get('name') not in cloneof_to_keep and i.get('cloneof') not in cloneof_to_keep]
 
     # Delete all game xml blocks that were marked for deletion and print final xml.
     del_xml_blocks(to_delete, tree, dat_out)

--- a/functions.py
+++ b/functions.py
@@ -87,20 +87,18 @@ def dat_clean(roms_to_keep, dat_file, dat_out=None, accuracy=90):
 
     # If game.get('name') does not fuzzy match source list, mark game for deletion.
     to_delete = []
-    parents_to_keep = []
+    cloneof_to_keep = []
     for game in root.iter('game'):
-        # Added to preserve parent/clone relationships
-        parent = game.get('cloneof')
-        if parent is None:
-            name = game.get('name')
-            result = process.extractOne(name, roms_to_keep, score_cutoff=accuracy, scorer=fuzz.token_set_ratio)
-            if not result:
-                to_delete.append(game)
-            else:
-                parents_to_keep.append(name)
+        name = game.get('name')
+        result = process.extractOne(name, roms_to_keep, score_cutoff=accuracy, scorer=fuzz.token_set_ratio)
+        if not result:
+            to_delete.append(game)
         else:
-            if parent not in parents_to_keep:
-                to_delete.append(game)
+            parent_name = game.get('cloneof')
+            if parent_name:
+                cloneof_to_keep.append(parent_name)
+    
+    to_delete = [i for i in to_delete if i.get('name') not in cloneof_to_keep or i.get('cloneof') not in cloneof_to_keep]
 
     # Delete all game xml blocks that were marked for deletion and print final xml.
     del_xml_blocks(to_delete, tree, dat_out)

--- a/vscrape/vscrape/spiders/vgames.py
+++ b/vscrape/vscrape/spiders/vgames.py
@@ -94,7 +94,7 @@ class VrecSpider(scrapy.Spider):
         if result.endswith(', The'):
             result = result[:-5]
 
-        result = result.replace(',', '').replace('é', 'e')
+        result = result.replace(',', '').replace('é', 'e').replace('*', '')
         result = result.strip()
         return cgi.escape(result)
 

--- a/vscrape/vscrape/spiders/vgames.py
+++ b/vscrape/vscrape/spiders/vgames.py
@@ -2,6 +2,7 @@ import scrapy
 import scrapy.exceptions
 import requests
 import re
+import cgi
 
 class VrecSpider(scrapy.Spider):
     """ Spider designed to scrape game titles from a V's recommended wiki page."""
@@ -78,15 +79,22 @@ class VrecSpider(scrapy.Spider):
 
     def clean_game_title(self, title):
         result = title.strip()
-        
-        if result.endswith('(series)') or result.endswith('(Series)'):
+        if result[-8:] in ['(series)','(Series)']:
             result = result[:-8]
             result = result.strip()
-        
+
+        if result.endswith(' /'):
+            result = result[:-2]
+            result = result.strip()
+
+        if result.startswith('/ '):
+            result = result[2:]
+            result = result.strip()
+
         if result.endswith(', The'):
             result = result[:-5]
 
-        result = result.replace(',', '')
+        result = result.replace(',', '').replace('é', 'e')
         result = result.strip()
-        return result
+        return cgi.escape(result)
 

--- a/vscrape/vscrape/spiders/vgames.py
+++ b/vscrape/vscrape/spiders/vgames.py
@@ -30,13 +30,12 @@ class VrecSpider(scrapy.Spider):
         :param response:
         :return:
         """
-
-        games_plain_text = response.css('table tr th::text').extract()
-        games_format_text = response.css('table tr th font::text').extract()
+        games_plain_text = response.css('table > tr:nth-child(n+2) > th::text').extract()
+        games_format_text = response.css('table > tr:nth-child(n+2) > th > font::text').extract()
         games = games_plain_text + games_format_text
-        games_clean = ([item.strip() for item in games])
+        games_clean = ([self.clean_game_title(item) for item in games])
         games_final = list(filter(None, games_clean))
-        yield {'games': games_final[3:]}
+        yield {'games': games_final}
 
     def parse_urls(self):
         """
@@ -63,3 +62,11 @@ class VrecSpider(scrapy.Spider):
             system = system.replace(" ", "_")
             parsedurls.append(main_system + '/' + system)
         return parsedurls
+
+    def clean_game_title(self, title):
+        result = title.strip()
+        if result.endswith(', The'):
+            result = result[:-5]
+        result = result.replace(',', '')
+        return result
+

--- a/vscrape/vscrape/spiders/vgames.py
+++ b/vscrape/vscrape/spiders/vgames.py
@@ -65,8 +65,11 @@ class VrecSpider(scrapy.Spider):
 
     def clean_game_title(self, title):
         result = title.strip()
+        if result.endswith('(series)') or result.endswith('(Series)'):
+            result = result[:-8]
         if result.endswith(', The'):
             result = result[:-5]
         result = result.replace(',', '')
+        result = result.strip()
         return result
 

--- a/vscrape/vscrape/spiders/vgames.py
+++ b/vscrape/vscrape/spiders/vgames.py
@@ -81,7 +81,7 @@ class VrecSpider(scrapy.Spider):
         
         if result.endswith('(series)') or result.endswith('(Series)'):
             result = result[:-8]
-            result = title.strip()
+            result = result.strip()
         
         if result.endswith(', The'):
             result = result[:-5]


### PR DESCRIPTION
I only tested with the SNES no-intro dat and it does the job correctly now.

Since you're using CSV as an intermediate storage solution for the scraped list, game names with commas make havoc when reading the CSV, e.g. if a game it's called "Game, The" in /v's list, ", The" will appear in the final game list and all games with a "The" will appear in the final dat.

At the same time, I made sure to retain parents and its clones effectively.

Take a look a the new commits, see if there's any odd effect in any other DAT and feel free to merge it in your repo.